### PR TITLE
Fix breaking change from Flask-Migrate

### DIFF
--- a/{{cookiecutter.app_name}}/requirements/prod.txt
+++ b/{{cookiecutter.app_name}}/requirements/prod.txt
@@ -12,7 +12,7 @@ Flask-SQLAlchemy==2.0
 SQLAlchemy==0.9.8
 
 # Migrations
-Flask-Migrate==1.3.0
+Flask-Migrate==1.3.1
 
 # Forms
 Flask-WTF==0.10.3


### PR DESCRIPTION
Flask-Migrate was recently patched to version 1.3.1 because [alembic versions can now include parts that are not integers](https://github.com/miguelgrinberg/Flask-Migrate/pull/51).

Requiring Flask-Migrate 1.3.0 installs a version of alembic that results in the following error message on startup:

`ValueError: invalid literal for int() with base 10: 'post2'`

Changing the requirements to install Flask-Migrate 1.3.1 fixes this problem.