### PR TITLE
Fix ScopeMismatch error when testing

### DIFF
--- a/{{cookiecutter.app_name}}/tests/conftest.py
+++ b/{{cookiecutter.app_name}}/tests/conftest.py
@@ -21,7 +21,7 @@ def app():
 
     ctx.pop()
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope='function')
 def testapp(app):
     """A Webtest app."""
     return TestApp(app)


### PR DESCRIPTION
If you cookiecut a new project right now, `python manage.py test` will have a few failed tests. This fixes them so that everything passes from the start.

The `testapp` fixture depends on the `app` fixture, but the `app` fixture's
scope was redefined as 'function' in commit 35c32eccc10795d273634125be7280c529a1d175, which is narrower than
the scope of `testapp` ('session').

Since `testapp` only depends only on `app`, it is safe to make it's scope match
`app`.