### PR TITLE
Python code clean-up (PEP-8 related and other)

### DIFF
--- a/{{cookiecutter.app_name}}/manage.py
+++ b/{{cookiecutter.app_name}}/manage.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import os
-import sys
-import subprocess
 from flask_script import Manager, Shell, Server
 from flask_migrate import MigrateCommand
 
@@ -21,11 +19,13 @@ TEST_PATH = os.path.join(HERE, 'tests')
 
 manager = Manager(app)
 
+
 def _make_context():
     """Return context dict for a shell session so you can access
     app, db, and the User model by default.
     """
     return {'app': app, 'db': db, 'User': User}
+
 
 @manager.command
 def test():
@@ -33,6 +33,7 @@ def test():
     import pytest
     exit_code = pytest.main([TEST_PATH, '--verbose'])
     return exit_code
+
 
 manager.add_command('server', Server())
 manager.add_command('shell', Shell(make_context=_make_context))

--- a/{{cookiecutter.app_name}}/tests/conftest.py
+++ b/{{cookiecutter.app_name}}/tests/conftest.py
@@ -11,6 +11,7 @@ from {{cookiecutter.app_name}}.database import db as _db
 
 from .factories import UserFactory
 
+
 @pytest.yield_fixture(scope='function')
 def app():
     _app = create_app(TestConfig)
@@ -21,10 +22,12 @@ def app():
 
     ctx.pop()
 
+
 @pytest.fixture(scope='session')
 def testapp(app):
     """A Webtest app."""
     return TestApp(app)
+
 
 @pytest.yield_fixture(scope='function')
 def db(app):

--- a/{{cookiecutter.app_name}}/tests/factories.py
+++ b/{{cookiecutter.app_name}}/tests/factories.py
@@ -5,6 +5,7 @@ from factory.alchemy import SQLAlchemyModelFactory
 from {{cookiecutter.app_name}}.user.models import User
 from {{cookiecutter.app_name}}.database import db
 
+
 class BaseFactory(SQLAlchemyModelFactory):
 
     class Meta:
@@ -20,4 +21,3 @@ class UserFactory(BaseFactory):
 
     class Meta:
         model = User
-

--- a/{{cookiecutter.app_name}}/tests/test_config.py
+++ b/{{cookiecutter.app_name}}/tests/test_config.py
@@ -2,6 +2,7 @@
 from {{cookiecutter.app_name}}.app import create_app
 from {{cookiecutter.app_name}}.settings import ProdConfig, DevConfig
 
+
 def test_production_config():
     app = create_app(ProdConfig)
     assert app.config['ENV'] == 'prod'

--- a/{{cookiecutter.app_name}}/tests/test_forms.py
+++ b/{{cookiecutter.app_name}}/tests/test_forms.py
@@ -5,6 +5,7 @@ from {{cookiecutter.app_name}}.public.forms import LoginForm
 from {{cookiecutter.app_name}}.user.forms import RegisterForm
 from .factories import UserFactory
 
+
 class TestRegisterForm:
 
     def test_validate_user_already_registered(self, user):

--- a/{{cookiecutter.app_name}}/tests/test_models.py
+++ b/{{cookiecutter.app_name}}/tests/test_models.py
@@ -7,6 +7,7 @@ import pytest
 from {{ cookiecutter.app_name }}.user.models import User, Role
 from .factories import UserFactory
 
+
 @pytest.mark.usefixtures('db')
 class TestUser:
 

--- a/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/app.py
+++ b/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/app.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-'''The app module, containing the app factory function.'''
+"""The app module, containing the app factory function."""
 from flask import Flask, render_template
 
 from {{cookiecutter.app_name}}.settings import ProdConfig
@@ -16,11 +16,11 @@ from {{cookiecutter.app_name}} import public, user
 
 
 def create_app(config_object=ProdConfig):
-    '''An application factory, as explained here:
+    """An application factory, as explained here:
         http://flask.pocoo.org/docs/patterns/appfactories/
 
     :param config_object: The configuration object to use.
-    '''
+    """
     app = Flask(__name__)
     app.config.from_object(config_object)
     register_extensions(app)

--- a/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/database.py
+++ b/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/database.py
@@ -11,6 +11,7 @@ from .compat import basestring
 Column = db.Column
 relationship = relationship
 
+
 class CRUDMixin(object):
     """Mixin that adds convenience methods for CRUD (create, read, update, delete)
     operations.
@@ -43,6 +44,7 @@ class CRUDMixin(object):
 class Model(CRUDMixin, db.Model):
     """Base model class that includes CRUD convenience methods."""
     __abstract__ = True
+
 
 # From Mike Bayer's "Building the app" talk
 # https://speakerdeck.com/zzzeek/building-the-app

--- a/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/public/__init__.py
+++ b/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/public/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
-'''The public module, including the homepage and user auth.'''
+"""The public module, including the homepage and user auth."""
 
 from . import views

--- a/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/public/forms.py
+++ b/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/public/forms.py
@@ -1,8 +1,10 @@
+# -*- coding: utf-8 -*-
 from flask_wtf import Form
 from wtforms import TextField, PasswordField
 from wtforms.validators import DataRequired
 
 from {{cookiecutter.app_name}}.user.models import User
+
 
 class LoginForm(Form):
     username = TextField('Username', validators=[DataRequired()])

--- a/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/public/views.py
+++ b/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/public/views.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-'''Public section, including homepage and signup.'''
+"""Public section, including homepage and signup."""
 from flask import (Blueprint, request, render_template, flash, url_for,
                     redirect, session)
 from flask.ext.login import login_user, login_required, logout_user
@@ -12,6 +12,7 @@ from {{cookiecutter.app_name}}.utils import flash_errors
 from {{cookiecutter.app_name}}.database import db
 
 blueprint = Blueprint('public', __name__, static_folder="../static")
+
 
 @login_manager.user_loader
 def load_user(id):
@@ -32,12 +33,14 @@ def home():
             flash_errors(form)
     return render_template("public/home.html", form=form)
 
+
 @blueprint.route('/logout/')
 @login_required
 def logout():
     logout_user()
     flash('You are logged out.', 'info')
     return redirect(url_for('public.home'))
+
 
 @blueprint.route("/register/", methods=['GET', 'POST'])
 def register():
@@ -52,6 +55,7 @@ def register():
     else:
         flash_errors(form)
     return render_template('public/register.html', form=form)
+
 
 @blueprint.route("/about/")
 def about():

--- a/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/settings.py
+++ b/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/settings.py
@@ -3,6 +3,7 @@ import os
 
 os_env = os.environ
 
+
 class Config(object):
     SECRET_KEY = os_env.get('{{cookiecutter.app_name | upper}}_SECRET', 'secret-key')  # TODO: Change me
     APP_DIR = os.path.abspath(os.path.dirname(__file__))  # This directory

--- a/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/user/__init__.py
+++ b/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/user/__init__.py
@@ -1,3 +1,3 @@
-'''The user module.'''
-
+# -*- coding: utf-8 -*-
+"""The user module."""
 from . import views

--- a/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/user/forms.py
+++ b/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/user/forms.py
@@ -1,8 +1,10 @@
+# -*- coding: utf-8 -*-
 from flask_wtf import Form
 from wtforms import TextField, PasswordField
 from wtforms.validators import DataRequired, Email, EqualTo, Length
 
 from .models import User
+
 
 class RegisterForm(Form):
     username = TextField('Username',

--- a/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/user/models.py
+++ b/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/user/models.py
@@ -26,6 +26,7 @@ class Role(SurrogatePK, Model):
     def __repr__(self):
         return '<Role({name})>'.format(name=self.name)
 
+
 class User(UserMixin, SurrogatePK, Model):
 
     __tablename__ = 'users'

--- a/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/user/views.py
+++ b/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/user/views.py
@@ -3,7 +3,7 @@ from flask import Blueprint, render_template
 from flask.ext.login import login_required
 
 blueprint = Blueprint("user", __name__, url_prefix='/users',
-                        static_folder="../static")
+                      static_folder="../static")
 
 
 @blueprint.route("/")

--- a/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/utils.py
+++ b/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/utils.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
-'''Helper utilities and decorators.'''
+"""Helper utilities and decorators."""
 from flask import flash
 
+
 def flash_errors(form, category="warning"):
-    '''Flash all errors for a form.'''
+    """Flash all errors for a form."""
     for field, errors in form.errors.items():
         for error in errors:
             flash("{0} - {1}"
-                    .format(getattr(form, field).label.text, error), category)
+                  .format(getattr(form, field).label.text, error), category)


### PR DESCRIPTION
- Add the UTF-8 marker to files without it.
- Fix some hanging indents.
- Change ''' into """ in docstrings.
- Enforce two blank line rule.