### PR TITLE
Only ignoring the env directory to avoid conflicts with alembic's env.py

### DIFF
--- a/{{cookiecutter.app_name}}/.gitignore
+++ b/{{cookiecutter.app_name}}/.gitignore
@@ -43,5 +43,4 @@ docs/_build
 .webassets-cache
 
 # Virtualenvs
-env
-env*
+env/


### PR DESCRIPTION
I looked for the minimal `env` related values suggested by gitignore.io which says just `env/`. They also recommend the following for virtualenv but I left it out:

```
### VirtualEnv ###
# Virtualenv
# http://iamzed.com/2009/05/07/a-primer-on-virtualenv/
.Python
[Bb]in
[Ii]nclude
[Ll]ib
[Ss]cripts
pyvenv.cfg
pip-selfcheck.json
```

Closes #44.