### PR TITLE
Add `urls` and `clean` commands to manage.py

### DIFF
--- a/{{cookiecutter.app_name}}/manage.py
+++ b/{{cookiecutter.app_name}}/manage.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 import os
 from flask_script import Manager, Shell, Server
+from flask_script.commands import Clean, ShowUrls
 from flask_migrate import MigrateCommand
 
 from {{cookiecutter.app_name}}.app import create_app
@@ -38,6 +39,8 @@ def test():
 manager.add_command('server', Server())
 manager.add_command('shell', Shell(make_context=_make_context))
 manager.add_command('db', MigrateCommand)
+manager.add_command("urls", ShowUrls())
+manager.add_command("clean", Clean())
 
 if __name__ == '__main__':
     manager.run()


### PR DESCRIPTION
Two new useful commands for manage.py. `m urls` lists all URLs (like `rake routes` in Rails). `m clean` gets rid of .pyc files.