### PR TITLE
Change iteritems() to items()

### DIFF
--- a/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/database.py
+++ b/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/database.py
@@ -25,7 +25,7 @@ class CRUDMixin(object):
 
     def update(self, commit=True, **kwargs):
         """Update specific fields of a record."""
-        for attr, value in kwargs.iteritems():
+        for attr, value in kwargs.items():
             setattr(self, attr, value)
         return commit and self.save() or self
 


### PR DESCRIPTION
Not sure if this project aims for Python 2 or 3 but I'm using 3 and kept getting an error “ 'dict' object has no attribute 'iteritems' ”.  Looked around and found [this helpful page](http://stackoverflow.com/questions/30418481/error-dict-object-has-no-attribute-iteritems-when-trying-to-use-networkx), tried the suggested change and everything works great now.  Looking at the python documentation, it -looks- like the change is backwards compatible for Python 2 users but I'm still new so don't quote me on that.