### PR TITLE
Fix an wrong invocation in nav.html

### DIFF
--- a/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/templates/nav.html
+++ b/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/templates/nav.html
@@ -22,7 +22,7 @@
       <li><a href="{{ url_for('public.home') }}">Home</a></li>
       <li><a href="{{ url_for('public.about') }}">About</a></li>
     </ul>
-    {% if current_user and current_user.is_authenticated %}
+    {% if current_user and current_user.is_authenticated() %}
     <ul class="nav navbar-nav navbar-right">
         <li>
             <p class="navbar-text"><a class="navbar-link" href="{{ url_for('user.members') }}">Logged in as {{ current_user.username }}</a></p>


### PR DESCRIPTION
the method `is_authenticated` is used wrong before. so whether logged in or not, the navigation bar displays as if logged in.

To fix it, invoke this method with **MERELY** a set of brackets