### PR TITLE
Switch CSRF token rendering mechanism.

### DIFF
--- a/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/templates/public/register.html
+++ b/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/templates/public/register.html
@@ -5,7 +5,7 @@
   <h1>Register</h1>
     <br/>
     <form id="registerForm" class="form form-register" method="POST" action="" role="form">
-            {{ form.hidden_tag() }}
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
             <div class="form-group">
                 {{form.username.label}}
                 {{form.username(placeholder="Username", class_="form-control")}}


### PR DESCRIPTION
Switch Register CSRF protect from form.hidden_tag to input hidden
value=csrf_token.
I don't understand why this is necessary, as form.hidden_tag works
in other situations. This may be a symptom of an aliasing issue. However, it was
the solution applied to fix login in a previous commit as described in
https://github.com/sloria/cookiecutter-flask/issues/34.

Without this change, the CSRF value is "None".