### PR TITLE
Use FLASK_DEBUG instead of MYFLASKAPP_ENV

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,11 @@ BSD licensed.
 Changelog
 ---------
 
+0.10.2 (09/10/2016)
+*******************
+
+- Use the FLASK_DEBUG system environment variable, instead of MYFLASKAPP_ENV, to control different configs for development and production environments
+
 0.10.1 (08/28/2016)
 *******************
 

--- a/{{cookiecutter.app_name}}/README.rst
+++ b/{{cookiecutter.app_name}}/README.rst
@@ -8,15 +8,18 @@
 Quickstart
 ----------
 
-First, set your app's secret key as an environment variable. For example, example add the following to ``.bashrc`` or ``.bash_profile``.
+First, set your app's secret key as an environment variable. For example,
+add the following to ``.bashrc`` or ``.bash_profile``.
 
 .. code-block:: bash
 
     export {{cookiecutter.app_name | upper}}_SECRET='something-really-secret'
 
-Before running shell commands, set the ``FLASK_APP`` environment variable ::
+Before running shell commands, set the ``FLASK_APP`` and ``FLASK_DEBUG``
+environment variables ::
 
     export FLASK_APP=/path/to/autoapp.py
+    export FLASK_DEBUG=1
 
 Then run the following commands to bootstrap your environment ::
 
@@ -28,7 +31,8 @@ Then run the following commands to bootstrap your environment ::
 
 You will see a pretty welcome screen.
 
-Once you have installed your DBMS, run the following to create your app's database tables and perform the initial migration ::
+Once you have installed your DBMS, run the following to create your app's
+database tables and perform the initial migration ::
 
     flask db init
     flask db migrate
@@ -39,7 +43,8 @@ Once you have installed your DBMS, run the following to create your app's databa
 Deployment
 ----------
 
-In your production environment, make sure the ``{{cookiecutter.app_name|upper}}_ENV`` environment variable is set to ``"prod"``.
+In your production environment, make sure the ``FLASK_DEBUG`` environment
+variable is unset or is set to ``0``, so that ``ProdConfig`` is used.
 
 
 Shell

--- a/{{cookiecutter.app_name}}/autoapp.py
+++ b/{{cookiecutter.app_name}}/autoapp.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 """Create an application instance."""
-import os
+from flask.helpers import get_debug_flag
 
 from {{cookiecutter.app_name}}.app import create_app
 from {{cookiecutter.app_name}}.settings import DevConfig, ProdConfig
 
-CONFIG = ProdConfig if os.environ.get('{{cookiecutter.app_name | upper}}_ENV') == 'prod' else DevConfig
+CONFIG = DevConfig if get_debug_flag() else ProdConfig
 
 app = create_app(CONFIG)


### PR DESCRIPTION
Use the new FLASK_DEBUG environment variable which is standard as of Flask 0.11, in order to control the use of dev or prod config.

Need to set this anyway, in order for "flask run" to use reloader and no concurrency.