### PR TITLE
Fix for Bcrypt and SqlAlchemy type casting in Postgres

### DIFF
--- a/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/user/models.py
+++ b/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/user/models.py
@@ -32,7 +32,7 @@ class User(UserMixin, SurrogatePK, Model):
     username = Column(db.String(80), unique=True, nullable=False)
     email = Column(db.String(80), unique=True, nullable=False)
     #: The hashed password
-    password = Column(db.String(128), nullable=True)
+    password = Column(db.Binary(128), nullable=True)
     created_at = Column(db.DateTime, nullable=False, default=dt.datetime.utcnow)
     first_name = Column(db.String(30), nullable=True)
     last_name = Column(db.String(30), nullable=True)


### PR DESCRIPTION
Hello,

I was running into an issue with an "Invalid Salt"  exception when checking user passwords with a Postgresql backend.  I was able to track the issue down to SqlAlchemy casting the hash to the incorrect type when `db.String` is specified.  Saving it as a `db.Binary` type because it is a Byte string remedies this issue.  

More info here: http://stackoverflow.com/a/37032208