### PR TITLE
specifiying setuptools/wheel will cause deployment to fail in Heroku

### DIFF
--- a/{{cookiecutter.app_name}}/requirements/prod.txt
+++ b/{{cookiecutter.app_name}}/requirements/prod.txt
@@ -1,8 +1,5 @@
 # Everything needed in production
 
-setuptools==20.2.2
-wheel==0.29.0
-
 # Flask
 Flask==0.11.1
 MarkupSafe==0.23


### PR DESCRIPTION
Setuptools and wheel are unnecessary in the requirements file and cause some PaaS to fail (namely Heroku)

Removing these has no downsides (as they will be present in a system with Python installed) and prevents that error from confusing new people.  

From Heroku:
```
remote:  !     The package setuptools/distribute is listed in requirements.txt.
remote:  !     Please remove to ensure expected behavior. 

...<snip>...

remote:            Uninstalling setuptools-25.2.0:
remote:              Successfully uninstalled setuptools-25.2.0
remote:          Rolling back uninstall of setuptools
remote:        Exception:
remote:        Traceback (most recent call last):
remote:          File "/app/.heroku/python/lib/python2.7/site-packages/pip-8.1.2-py2.7.egg/pip/basecommand.py", line 215, in main
remote:            status = self.run(options, args)
remote:          File "/app/.heroku/python/lib/python2.7/site-packages/pip-8.1.2-py2.7.egg/pip/commands/install.py", line 317, in run
remote:            prefix=options.prefix_path,
remote:          File "/app/.heroku/python/lib/python2.7/site-packages/pip-8.1.2-py2.7.egg/pip/req/req_set.py", line 742, in install
remote:            **kwargs
remote:          File "/app/.heroku/python/lib/python2.7/site-packages/pip-8.1.2-py2.7.egg/pip/req/req_install.py", line 831, in install
remote:            self.move_wheel_files(self.source_dir, root=root, prefix=prefix)
remote:          File "/app/.heroku/python/lib/python2.7/site-packages/pip-8.1.2-py2.7.egg/pip/req/req_install.py", line 1032, in move_wheel_files
remote:            isolated=self.isolated,
remote:          File "/app/.heroku/python/lib/python2.7/site-packages/pip-8.1.2-py2.7.egg/pip/wheel.py", line 247, in move_wheel_files
remote:            prefix=prefix,
remote:          File "/app/.heroku/python/lib/python2.7/site-packages/pip-8.1.2-py2.7.egg/pip/locations.py", line 140, in distutils_scheme
remote:            d = Distribution(dist_args)
remote:          File "build/bdist.linux-x86_64/egg/setuptools/dist.py", line 349, in __init__
remote:            for ep in pkg_resources.iter_entry_points('distutils.setup_keywords'):
remote:          File "build/bdist.linux-x86_64/egg/pkg_resources/__init__.py", line 706, in iter_entry_points
remote:            entries = dist.get_entry_map(group)
remote:          File "build/bdist.linux-x86_64/egg/pkg_resources/__init__.py", line 2578, in get_entry_map
remote:            self._get_metadata('entry_points.txt'), self
remote:          File "build/bdist.linux-x86_64/egg/pkg_resources/__init__.py", line 2308, in parse_map
remote:            for group, lines in data:
remote:          File "build/bdist.linux-x86_64/egg/pkg_resources/__init__.py", line 2904, in split_sections
remote:            for line in yield_lines(s):
remote:          File "build/bdist.linux-x86_64/egg/pkg_resources/__init__.py", line 2175, in yield_lines
remote:            for ss in strs:
remote:          File "build/bdist.linux-x86_64/egg/pkg_resources/__init__.py", line 2503, in _get_metadata
remote:            if self.has_metadata(name):
remote:          File "build/bdist.linux-x86_64/egg/pkg_resources/__init__.py", line 1469, in has_metadata
remote:            return self.egg_info and self._has(self._fn(self.egg_info, name))
remote:          File "build/bdist.linux-x86_64/egg/pkg_resources/__init__.py", line 1825, in _has
remote:            return zip_path in self.zipinfo or zip_path in self._index()
remote:          File "build/bdist.linux-x86_64/egg/pkg_resources/__init__.py", line 1705, in zipinfo
remote:            return self._zip_manifests.load(self.loader.archive)
remote:          File "build/bdist.linux-x86_64/egg/pkg_resources/__init__.py", line 1645, in load
remote:            mtime = os.stat(path).st_mtime
remote:        OSError: [Errno 2] No such file or directory: '/app/.heroku/python/lib/python2.7/site-packages/setuptools-25.2.0-py2.7.egg'
remote:  !     Push rejected, failed to compile Python app.
remote: 
remote:  !     Push failed
```