### PR TITLE
Pass `app_name` instead of `app_name.app` to Flask

### DIFF
--- a/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/app.py
+++ b/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/app.py
@@ -13,7 +13,7 @@ def create_app(config_object=ProdConfig):
 
     :param config_object: The configuration object to use.
     """
-    app = Flask(__name__)
+    app = Flask(__name__.split('.')[0])
     app.config.from_object(config_object)
     register_extensions(app)
     register_blueprints(app)


### PR DESCRIPTION
This passes `app_name` instead of the current `app_name.app` to Flask. Please see `About the First Parameter` note in http://flask.pocoo.org/docs/0.11/api/