### PR TITLE
Fixed flask app initialization for Travis CI

### DIFF
--- a/{{cookiecutter.app_name}}/.travis.yml
+++ b/{{cookiecutter.app_name}}/.travis.yml
@@ -1,6 +1,8 @@
 # Config file for automatic testing at travis-ci.org
 sudo: false  # http://docs.travis-ci.com/user/migrating-from-legacy/
 language: python
+env:
+- FLASK_APP=autoapp.py FLASK_DEBUG=1
 python:
   - 2.7
   - 3.4


### PR DESCRIPTION
The environment variable `FLASK_APP` must be set for proper initialization with Travis CI.

See difference from the first and last build [here](https://travis-ci.org/wernersa/wersav_web/builds).