### PR TITLE
package.json: specify engines with node>=4

### DIFF
--- a/{{cookiecutter.app_name}}/package.json
+++ b/{{cookiecutter.app_name}}/package.json
@@ -15,6 +15,7 @@
   },
   "author": "{{cookiecutter.full_name}}",
   "license": "BSD-3-Clause",
+  "engines": { "node" : ">=4" },
   "bugs": {
     "url": "https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.app_name}}/issues"
   },


### PR DESCRIPTION
Specify minimum viable version of node in the package.json file.

This should help triage issues like #213 and #218 which are due to people running the project with very old installs of nodejs.