### PR TITLE
remove the db. by using the alias

### DIFF
--- a/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/database.py
+++ b/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/database.py
@@ -49,7 +49,7 @@ class SurrogatePK(object):
 
     __table_args__ = {'extend_existing': True}
 
-    id = db.Column(db.Integer, primary_key=True)
+    id = Column(db.Integer, primary_key=True)
 
     @classmethod
     def get_by_id(cls, record_id):
@@ -70,6 +70,6 @@ def reference_col(tablename, nullable=False, pk_name='id', **kwargs):
         category_id = reference_col('category')
         category = relationship('Category', backref='categories')
     """
-    return db.Column(
+    return Column(
         db.ForeignKey('{0}.{1}'.format(tablename, pk_name)),
         nullable=nullable, **kwargs)


### PR DESCRIPTION
Since the alias have been defined, it is better to make the code clear and consistent 