### PR TITLE
Using flask-wtf helper for csrf token field

### DIFF
--- a/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/templates/public/register.html
+++ b/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/templates/public/register.html
@@ -5,7 +5,7 @@
   <h1>Register</h1>
     <br/>
     <form id="registerForm" class="form form-register" method="POST" action="" role="form">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+           {{ form.csrf_token }}
             <div class="form-group">
                 {{form.username.label}}
                 {{form.username(placeholder="Username", class_="form-control")}}


### PR DESCRIPTION
Not sure if you are not using the [csrf-helper from flask-wtf](http://flask-wtf.readthedocs.io/en/stable/quickstart.html) for a specific reason. In case you do, then sorry for the noise. Otherwise here is a PR which uses the helper.

### HTML from your version:

`<input type="hidden" name="csrf_token" value="IjRjMGI2NTAwNTg5ZmNlMDY4YWNjM2I3OTIxZDhjNjczMjBhNTJiNTAi.DZ-BMA.-57kVA-q_uwyhQkE9yt-X5NIL0s"/>`

### HTML via helper:

`<input id="csrf_token" name="csrf_token" type="hidden" value="IjRjMGI2NTAwNTg5ZmNlMDY4YWNjM2I3OTIxZDhjNjczMjBhNTJiNTAi.DZ-Ayg.F-yS07h6u0zSZZyQIj4UymcLSbs">`