### PR TITLE
Downgrade webpack-dev-server pending webpack4 support.

### DIFF
--- a/{{cookiecutter.app_name}}/package.json
+++ b/{{cookiecutter.app_name}}/package.json
@@ -46,7 +46,7 @@
     "style-loader": "^0.23.0",
     "url-loader": "^1.0.1",
     "webpack": "^2.6.1",
-    "webpack-dev-server": "^3.1.5",
+    "webpack-dev-server": "^2.11.1",
     "sync-exec": "^0.6.2"
   }
 }


### PR DESCRIPTION
Fixes issue #336, currently `webpack-dev-server` exits with an error due to changes
in the webpack api and `webpack-cli` being split out in webpack 4. `webpack-dev-server` 3.x does not appear to support webpack 2.6.